### PR TITLE
chore: modernize to new algorithm parameters API

### DIFF
--- a/src/PartSeg_smfish/segmentation.py
+++ b/src/PartSeg_smfish/segmentation.py
@@ -1,6 +1,6 @@
 import operator
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from copy import deepcopy
 
 import numpy as np
@@ -418,7 +418,7 @@ def gauss_background_estimate(
 def _gauss_background_estimate_mask(
     channel: np.ndarray,
     mask: np.ndarray,
-    scale: list[float] | tuple[float | int],
+    scale: Sequence[float],
     background_gauss_radius: float,
     foreground_gauss_radius: float,
 ) -> np.ndarray:
@@ -439,7 +439,7 @@ def _gauss_background_estimate_mask(
 
 def _gauss_background_estimate(
     channel: np.ndarray,
-    scale: list[float] | tuple[float | int],
+    scale: Sequence[float],
     background_gauss_radius: float,
     foreground_gauss_radius: float,
 ) -> np.ndarray:


### PR DESCRIPTION
Use new API to stop following warning:

```
/home/czaki/Projekty/PartSeg-smfish/src/PartSeg_smfish/segmentation.py:236: FutureWarning: Access to attribute by [] is deprecated. Use . instead
  self.new_parameters["nucleus_threshold"]["values"],
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved type hinting for better clarity.
  * Updated import statements for consistency.
  * Renamed some internal variables for clarity.
  * Switched to attribute-style access for certain values.

No changes to app functionality or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->