### PR TITLE
Fix shape of roi to fix saving in batch processing

### DIFF
--- a/src/PartSeg_smfish/segmentation.py
+++ b/src/PartSeg_smfish/segmentation.py
@@ -740,12 +740,14 @@ class ThresholdFlowAlgorithmWithDilation(ThresholdFlowAlgorithm):
         neigh, dist = calculate_distances_array(
             self.image.spacing, get_neigh(True)
         )
-        roi = euclidean_sprawl(
-            sprawl_area,
-            res.roi,
-            components_num,
-            neigh,
-            dist,
+        roi = self.image.fit_array_to_image(
+            euclidean_sprawl(
+                sprawl_area,
+                res.roi,
+                components_num,
+                neigh,
+                dist,
+            )
         )
 
         res2 = ROIExtractionResult(


### PR DESCRIPTION
Workaround for bug in PartSeg of not fixing ROI shape before save in batch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of ROI processing by ensuring output is properly adapted to the image format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->